### PR TITLE
Fix 'calculate_grammar' option name, remove unused code, small __init__ improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The effect of the reduced grammar is: __almost 0% word error rate__ (tested over
 ```yml
   - vosk:
       model_path: "<relative or absolute directory path to your language model>"
-      calculate_grammer: False
+      calculate_grammar: False
 ```
 
 


### PR DESCRIPTION
* Remove unused imports
* Use option name 'calculate_grammar' as in the readme
* Call logger.info on Model creation since it can take 10 seconds for a large model
* Similar to Model, cache KaldiRecognizer object in a class attribute. It saves some milliseconds on each recognition
* AcceptWaveform() already raises when return code < 0, don't need to check
* Remove speech_recognition code as it is not used